### PR TITLE
Promises and ts1.6 (fixes #18, fixes #22)

### DIFF
--- a/pouchdb-tests.ts
+++ b/pouchdb-tests.ts
@@ -14,16 +14,18 @@ module promise {
         foo: string;
     }
 
-    class fakePromise<T> implements pouchdb.async.Thenable<T> {
+    class fakePromise<T> implements Promise<T> {
         new() { }
 
-        then<R>(onFulfilled?: (value: T) => pouchdb.async.Thenable<R> | R, onRejected?: (error: any) => pouchdb.async.Thenable<R> | R) {
+        then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: any) => Promise<R> | R) {
             return new fakePromise<R>();
         }
 
-        catch<R>(onRejected: (error: any) => pouchdb.async.Thenable<R> | R) {
+        catch<R>(onRejected: (error: any) => Promise<R> | R) {
             return undefined;
         }
+
+        [Symbol.toStringTag]: string;
     }
 
     function chainedThen() {

--- a/pouchdb-tests.ts
+++ b/pouchdb-tests.ts
@@ -9,34 +9,34 @@
 /// <reference path="pouchdb-loose.d.ts" />
 /// <reference path="pouchdb-plugins.d.ts" />
 
-module promise {
-    class Foo {
-        foo: string;
-    }
-
-    class fakePromise<T> implements Promise<T> {
-        new() { }
-
-        then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: any) => Promise<R> | R) {
-            return new fakePromise<R>();
-        }
-
-        catch<R>(onRejected: (error: any) => Promise<R> | R) {
-            return undefined;
-        }
-
-        [Symbol.toStringTag]: string;
-    }
-
-    function chainedThen() {
-        var fooOut: string;
-        new PouchDB("dbname")
-            .then((db) => new fakePromise<Foo>())
-            .then((value: Foo) => { fooOut = value.foo; });
-    }
-}
-
 module PouchDBTest {
+    module promise {
+        class Foo {
+            foo: string;
+        }
+
+        class fakePromise<T> implements Promise<T> {
+            new() { }
+
+            then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: any) => Promise<R> | R) {
+                return new fakePromise<R>();
+            }
+
+            catch<R>(onRejected: (error: any) => Promise<R> | R) {
+                return undefined;
+            }
+
+            [Symbol.toStringTag]: string;
+        }
+
+        function chainedThen() {
+            var fooOut: string;
+            new PouchDB("dbname")
+                .then((db) => new fakePromise<Foo>())
+                .then((value: Foo) => { fooOut = value.foo; });
+        }
+    }
+
     module localDb {
         // common variables
         var dbt: pouchdb.thenable.PouchDB;

--- a/pouchdb-tests.ts
+++ b/pouchdb-tests.ts
@@ -14,16 +14,18 @@ module promise {
         foo: string;
     }
 
-    class fakePromise<T> implements GlobalPromise<T> {
+    class fakePromise<T> implements Promise<T> {
         new() { }
 
-        then<R>(onFulfilled?: (value: T) => GlobalPromise<R> | R, onRejected?: (error: any) => GlobalPromise<R> | R) {
+        then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: any) => Promise<R> | R) {
             return new fakePromise<R>();
         }
 
-        catch<R>(onRejected: (error: any) => GlobalPromise<R> | R) {
+        catch<R>(onRejected: (error: any) => Promise<R> | R) {
             return undefined;
         }
+
+        [Symbol.toStringTag]: string;
     }
 
     function chainedThen() {

--- a/pouchdb-tests.ts
+++ b/pouchdb-tests.ts
@@ -14,18 +14,16 @@ module promise {
         foo: string;
     }
 
-    class fakePromise<T> implements Promise<T> {
+    class fakePromise<T> implements GlobalPromise<T> {
         new() { }
 
-        then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: any) => Promise<R> | R) {
+        then<R>(onFulfilled?: (value: T) => GlobalPromise<R> | R, onRejected?: (error: any) => GlobalPromise<R> | R) {
             return new fakePromise<R>();
         }
 
-        catch<R>(onRejected: (error: any) => Promise<R> | R) {
+        catch<R>(onRejected: (error: any) => GlobalPromise<R> | R) {
             return undefined;
         }
-
-        [Symbol.toStringTag]: string;
     }
 
     function chainedThen() {

--- a/pouchdb.d.ts
+++ b/pouchdb.d.ts
@@ -126,7 +126,7 @@ declare module pouchdb {
         }
     }
     /**
-     * Contains the standard pouchdb promises
+     * Contains the standard pouchdb promise utilities
      * @todo what is the error shape? looks like they contain status/reason/message and id(s)?
      */
     module async {
@@ -139,13 +139,6 @@ declare module pouchdb {
             error?: any;
             message?: string;
             status?: number;
-        }
-        /** An interface to represent a promise object */
-        interface Thenable<T> {
-            /** A Promises/A+ `then` implementation */
-            then<R>(onFulfilled?: (value: T) => Thenable<R>|R, onRejected?: (error: Error) => Thenable<R>|R): Thenable<R>;
-            /** `catch` implementation as per the pouchdb example docs */
-            catch<R>(onRejected: (error: Error) => Thenable<R>|R): Thenable<R>;
         }
         /** Callback alternatives to promised */
         interface Callback<T> {
@@ -338,13 +331,13 @@ declare module pouchdb {
                 /** Promise pattern for allDocs() */
                 interface Promise {
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(): async.Thenable<Response>;
+                    allDocs(): GlobalPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(options: RangeOptions): async.Thenable<Response>;
+                    allDocs(options: RangeOptions): GlobalPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(options: PaginationOptions): async.Thenable<Response>;
+                    allDocs(options: PaginationOptions): GlobalPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(options: FilterOptions): async.Thenable<Response>;
+                    allDocs(options: FilterOptions): GlobalPromise<Response>;
                 }
             }
 
@@ -480,40 +473,40 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(folder: DocumentPouch<ExistingDoc>, options?: BulkDocsOptions): async.Thenable<BulkDocsResponse[]>;
+                    bulkDocs(folder: DocumentPouch<ExistingDoc>, options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
                     /**
                      * Update/Delete each doc in an array of documents.
                      * @param doc the doc
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(docs: ExistingDoc[], options?: BulkDocsOptions): async.Thenable<BulkDocsResponse[]>;
+                    bulkDocs(docs: ExistingDoc[], options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
                     /**
                      * Create multiple documents.
                      * @param doc the doc
                      * @param options
                      */
-                    bulkDocs(folder: DocumentPouch<NewDoc>): async.Thenable<BulkDocsResponse[]>;
+                    bulkDocs(folder: DocumentPouch<NewDoc>): GlobalPromise<BulkDocsResponse[]>;
                     /**
                      * Create multiple documents.
                      * @param doc the doc
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(docs: NewDoc[], options?: BulkDocsOptions): async.Thenable<BulkDocsResponse[]>;
+                    bulkDocs(docs: NewDoc[], options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
                     /**
                      * Perform mixed Create/Update/Delete operations on multiple documents.
                      * @param docs the documents to act on
                      * @param options
                      */
-                    bulkDocs(folder: DocumentPouch<MixedDoc>): async.Thenable<BulkDocsResponse[]>;
+                    bulkDocs(folder: DocumentPouch<MixedDoc>): GlobalPromise<BulkDocsResponse[]>;
                     /**
                      * Perform mixed Create/Update/Delete operations on multiple documents.
                      * @param docs the documents to act on
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(docs: MixedDoc[], options?: BulkDocsOptions): async.Thenable<BulkDocsResponse[]>;
+                    bulkDocs(docs: MixedDoc[], options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
                 }
             }
 
@@ -690,7 +683,7 @@ declare module pouchdb {
                 /** Promise pattern for close() */
                 interface Promise {
                     /** Closes the pouchdb */
-                    close(): async.Thenable<string>;
+                    close(): GlobalPromise<string>;
                 }
             }
 
@@ -724,7 +717,7 @@ declare module pouchdb {
                      * Deletes a database
                      * @param options ajax options
                      */
-                    destroy(options?: options.OptionsWithAjax): async.Thenable<Info>;
+                    destroy(options?: options.OptionsWithAjax): GlobalPromise<Info>;
                 }
             }
 
@@ -803,7 +796,7 @@ declare module pouchdb {
                      * @param docId the doc id
                      * @param options
                      */
-                    get<R extends ExistingDoc>(docId: string, options?: Options): async.Thenable<R>;
+                    get<R extends ExistingDoc>(docId: string, options?: Options): GlobalPromise<R>;
                 }
             }
 
@@ -817,7 +810,7 @@ declare module pouchdb {
                 /** Promise pattern for `id()` */
                 interface Promise {
                     /** Returns the instance id for the pouchdb */
-                    id(): async.Thenable<string>;
+                    id(): GlobalPromise<string>;
                 }
             }
 
@@ -852,7 +845,7 @@ declare module pouchdb {
                 /** Promise pattern for `info()` */
                 interface Promise {
                     /** Returns the instance info for the pouchdb */
-                    info(): async.Thenable<Response | ResponseDebug>;
+                    info(): GlobalPromise<Response | ResponseDebug>;
                 }
             }
 
@@ -890,7 +883,7 @@ declare module pouchdb {
                      * @param options ajax options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    post(doc: BaseDoc, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    post(doc: BaseDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                 }
             }
 
@@ -971,14 +964,14 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: ExistingDoc, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    put(doc: ExistingDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                     /**
                      * Create a new document.
                      * @param doc the doc
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: NewDoc, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    put(doc: NewDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                     /**
                      * Update an existing document.
                      * @param doc the doc
@@ -987,7 +980,7 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: BaseDoc, docId: string, docRev: string, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    put(doc: BaseDoc, docId: string, docRev: string, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                     /**
                      * Create a new document. If the document already exists,
                      * you must use the update overload otherwise a conflict will occur.
@@ -996,7 +989,7 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: BaseDoc, docId: string, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    put(doc: BaseDoc, docId: string, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                 }
             }
 
@@ -1070,7 +1063,7 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    remove(docId: string, docRev: string, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    remove(docId: string, docRev: string, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                     /**
                      * Deletes the document.
                      * `doc` is required to be a document with at least an `_id` and a `_rev` property.
@@ -1079,14 +1072,14 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    remove(doc: ExistingDoc, options?: options.EmptyOptions): async.Thenable<OperationResponse>;
+                    remove(doc: ExistingDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
                     /**
                      * Deletes the document.
                      * `doc` is required to be a document with at least an `_id` property, `rev` is specified in the `options`.
                      * @param doc the doc (with only an `id` property)
                      * @param options options that specify
                      */
-                    remove(doc: NewDoc, options: RevOptions): async.Thenable<OperationResponse>;
+                    remove(doc: NewDoc, options: RevOptions): GlobalPromise<OperationResponse>;
                 }
             }
         }
@@ -1241,7 +1234,7 @@ declare module pouchdb {
          * Usually only a `pouchdb.promise.PouchDB` reference would be kept, assigned by
          * the `then` of the constructor.
          */
-        interface PouchDB extends promise.PouchDB, async.Thenable<promise.PouchDB> { }
+        interface PouchDB extends promise.PouchDB, GlobalPromise<promise.PouchDB> { }
     }
 
     /** Static-side interface for PouchDB */
@@ -1379,4 +1372,14 @@ declare module pouchdb {
          */
         new (options: options.ctor.DbName): thenable.PouchDB;
     }
+}
+
+/** Merges declaration with another supplied interface to represent a promise object with custom error typings */
+interface GlobalPromise<T> extends Promise<T> {
+    /** A Promises/A+ `then` implementation */
+    then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
+    then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
+    /** `catch` implementation as per the pouchdb example docs */
+    catch<R>(onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
+    catch<R>(onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
 }

--- a/pouchdb.d.ts
+++ b/pouchdb.d.ts
@@ -1261,7 +1261,7 @@ declare module pouchdb {
          * Creates a new local pouchDb with the name specified and
          * all the default options
          * @param name the database name
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (name: string): thenable.PouchDB;
         /**
@@ -1279,7 +1279,7 @@ declare module pouchdb {
          * Creates a new local SQLite pouchDb with the name and options provided
          * @param name the database name
          * @param options the SQlite database options
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (name: string, options: options.ctor.LocalSQLiteDb): thenable.PouchDB;
         /**
@@ -1294,7 +1294,7 @@ declare module pouchdb {
         /**
          * Creates a new local SQLite pouchDb with the options provided
          * @param options the SQlite database options, including the name
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (options: options.ctor.LocalSQLiteDbWithName): thenable.PouchDB;
         /**
@@ -1310,7 +1310,7 @@ declare module pouchdb {
          * Creates a new local WebSQL pouchDb with the name and options provided
          * @param name A string value that specifies the database name
          * @param options An object that specifies the local database options
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (name: string, options: options.ctor.LocalWebSQLDb): thenable.PouchDB;
         /**
@@ -1325,7 +1325,7 @@ declare module pouchdb {
         /**
          * Creates a new local WebSQL pouchDb with the options provided
          * @param options An object that specifies the local database options
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (options: options.ctor.LocalWebSQLDbWithName): thenable.PouchDB;
         /**
@@ -1341,7 +1341,7 @@ declare module pouchdb {
          * Creates a new local pouchDb with the name and options provided
          * @param name the database name
          * @param options the local database options
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (name: string, options: options.ctor.LocalDb): thenable.PouchDB;
         /**
@@ -1356,7 +1356,7 @@ declare module pouchdb {
         /**
          * Creates a new local pouchDb with the options provided
          * @param options the local database options, including the name
-         * @returns a Thenable<PouchDB>
+         * @returns a thenable.PouchDB
          */
         new (options: options.ctor.LocalDbWithName): thenable.PouchDB;
         /**
@@ -1372,12 +1372,14 @@ declare module pouchdb {
          * A fallback constructor if none of the typed constructors cover a use case
          * @todo if you find yourself using this, consider contributing a patch
          * to add/improve the necessary typed overload instead of `options: any`
+         * @returns a thenable.PouchDB
          */
         new (name: string, options: any): thenable.PouchDB;
         /**
          * A fallback constructor if none of the typed constructors cover a use case
          * @todo if you find yourself using this, consider contributing a patch
          * to add/improve the necessary typed overload instead of `options: pouchdb.options.DbName`
+         * @returns a thenable.PouchDB
          */
         new (options: options.ctor.DbName): thenable.PouchDB;
     }

--- a/pouchdb.d.ts
+++ b/pouchdb.d.ts
@@ -337,7 +337,7 @@ declare module pouchdb {
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
                     allDocs(options: FilterOptions, callback?: async.Callback<Response>): void;
                 }
-                /** Promisable pattern for allDocs() */
+                /** Promise pattern for allDocs() */
                 interface Promisable {
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
                     allDocs(): async.PouchPromise<Response>;
@@ -474,7 +474,7 @@ declare module pouchdb {
                      */
                     bulkDocs(docs: MixedDoc[], options: BulkDocsOptions, callback?: async.Callback<BulkDocsResponse[]>): void;
                 }
-                /** Promisable pattern for bulkDocs() */
+                /** Promise pattern for bulkDocs() */
                 interface Promisable {
                     /**
                      * Update/Delete each doc in an array of documents.
@@ -678,7 +678,7 @@ declare module pouchdb {
                 }
                 /** Callback pattern for changes() */
                 interface Callback { }
-                /** Promisable pattern for changes() */
+                /** Promise pattern for changes() */
                 interface Promisable { }
             }
 
@@ -689,7 +689,7 @@ declare module pouchdb {
                     /** Closes the pouchdb */
                     close(callback?: async.Callback<string>): void;
                 }
-                /** Promisable pattern for close() */
+                /** Promise pattern for close() */
                 interface Promisable {
                     /** Closes the pouchdb */
                     close(): async.PouchPromise<string>;
@@ -719,7 +719,7 @@ declare module pouchdb {
                     destroy(callback?: async.Callback<Info>): void;
                 }
                 /**
-                 * Promisable pattern for destroy
+                 * Promise pattern for destroy
                  */
                 interface Promisable {
                     /**
@@ -798,7 +798,7 @@ declare module pouchdb {
                      */
                     get<R extends Response>(docId: string, options: Options, callback?: async.Callback<R>): void;
                 }
-                /** Promisable pattern for remove */
+                /** Promise pattern for remove */
                 interface Promisable {
                     /**
                      * Retrieves a document, specified by `docId`.
@@ -816,7 +816,7 @@ declare module pouchdb {
                     /** Returns the instance id for the pouchdb */
                     id(callback?: async.Callback<string>): void;
                 }
-                /** Promisable pattern for `id()` */
+                /** Promise pattern for `id()` */
                 interface Promisable {
                     /** Returns the instance id for the pouchdb */
                     id(): async.PouchPromise<string>;
@@ -851,7 +851,7 @@ declare module pouchdb {
                     /** Returns the instance info for the pouchdb */
                     info(callback?: async.Callback<Response | ResponseDebug>): void;
                 }
-                /** Promisable pattern for `info()` */
+                /** Promise pattern for `info()` */
                 interface Promisable {
                     /** Returns the instance info for the pouchdb */
                     info(): async.PouchPromise<Response | ResponseDebug>;
@@ -883,7 +883,7 @@ declare module pouchdb {
                      */
                     post(doc: BaseDoc, options: options.EmptyOptions, callback?: async.Callback<OperationResponse>): void;
                 }
-                /** Promisable pattern for post */
+                /** Promise pattern for post */
                 interface Promisable {
                     /**
                      * Create a new document and let PouchDB auto-generate an _id for it.
@@ -965,7 +965,7 @@ declare module pouchdb {
                      */
                     put(doc: BaseDoc, docId: string, options: options.EmptyOptions, callback?: async.Callback<OperationResponse>): void;
                 }
-                /** Promisable pattern for put */
+                /** Promise pattern for put */
                 interface Promisable {
                     /**
                      * Update an existing document.
@@ -1061,7 +1061,7 @@ declare module pouchdb {
                      */
                     remove(doc: NewDoc, options: RevOptions, callback?: async.Callback<OperationResponse>): void;
                 }
-                /** Promisable pattern for remove */
+                /** Promise pattern for remove */
                 interface Promisable {
                     /**
                      * Deletes the document.
@@ -1231,15 +1231,15 @@ declare module pouchdb {
         /** The main pouchDB interface (callback pattern) */
         interface PouchDB extends api.db.Callback { }
     }
-    /** The api module for the pouchdb Promisable pattern */
+    /** The api module for the pouchdb promise pattern */
     module promise {
-        /** The main pouchDB interface (Promisable pattern) */
+        /** The main pouchDB interface (promise pattern) */
         interface PouchDB extends api.db.Promisable { }
     }
     /** The api module for the pouchdb promise pattern (constructor only) */
     module thenable {
         /**
-         * Special case class returned by the constructors of the Promisable api pouchDB.
+         * Special case class returned by the constructors of the promise api pouchDB.
          * Usually only a `pouchdb.promise.PouchDB` reference would be kept, assigned by
          * the `then` of the constructor.
          */
@@ -1253,7 +1253,7 @@ declare module pouchdb {
     }
     /**
      * The main pouchDB entry point. The constructors here will return either a
-     * Callback or Promisable pattern api.
+     * Callback or Promise pattern api.
      */
     export interface PouchDB {
         //////////////////////////////  local db  /////////////////////////////

--- a/pouchdb.d.ts
+++ b/pouchdb.d.ts
@@ -140,6 +140,15 @@ declare module pouchdb {
             message?: string;
             status?: number;
         }
+        /** Overrides a supplied interface to represent a promise object with custom error typings for the first pass */
+        export interface PouchPromise<T> extends Promise<T> {
+            /** A Promises/A+ `then` implementation */
+            then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
+            then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
+            /** `catch` implementation as per the pouchdb example docs */
+            catch<R>(onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
+            catch<R>(onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
+        }
         /** Callback alternatives to promised */
         interface Callback<T> {
             /**
@@ -331,13 +340,13 @@ declare module pouchdb {
                 /** Promise pattern for allDocs() */
                 interface Promise {
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(): GlobalPromise<Response>;
+                    allDocs(): async.PouchPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(options: RangeOptions): GlobalPromise<Response>;
+                    allDocs(options: RangeOptions): async.PouchPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(options: PaginationOptions): GlobalPromise<Response>;
+                    allDocs(options: PaginationOptions): async.PouchPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
-                    allDocs(options: FilterOptions): GlobalPromise<Response>;
+                    allDocs(options: FilterOptions): async.PouchPromise<Response>;
                 }
             }
 
@@ -473,40 +482,40 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(folder: DocumentPouch<ExistingDoc>, options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
+                    bulkDocs(folder: DocumentPouch<ExistingDoc>, options?: BulkDocsOptions): async.PouchPromise<BulkDocsResponse[]>;
                     /**
                      * Update/Delete each doc in an array of documents.
                      * @param doc the doc
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(docs: ExistingDoc[], options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
+                    bulkDocs(docs: ExistingDoc[], options?: BulkDocsOptions): async.PouchPromise<BulkDocsResponse[]>;
                     /**
                      * Create multiple documents.
                      * @param doc the doc
                      * @param options
                      */
-                    bulkDocs(folder: DocumentPouch<NewDoc>): GlobalPromise<BulkDocsResponse[]>;
+                    bulkDocs(folder: DocumentPouch<NewDoc>): async.PouchPromise<BulkDocsResponse[]>;
                     /**
                      * Create multiple documents.
                      * @param doc the doc
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(docs: NewDoc[], options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
+                    bulkDocs(docs: NewDoc[], options?: BulkDocsOptions): async.PouchPromise<BulkDocsResponse[]>;
                     /**
                      * Perform mixed Create/Update/Delete operations on multiple documents.
                      * @param docs the documents to act on
                      * @param options
                      */
-                    bulkDocs(folder: DocumentPouch<MixedDoc>): GlobalPromise<BulkDocsResponse[]>;
+                    bulkDocs(folder: DocumentPouch<MixedDoc>): async.PouchPromise<BulkDocsResponse[]>;
                     /**
                      * Perform mixed Create/Update/Delete operations on multiple documents.
                      * @param docs the documents to act on
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    bulkDocs(docs: MixedDoc[], options?: BulkDocsOptions): GlobalPromise<BulkDocsResponse[]>;
+                    bulkDocs(docs: MixedDoc[], options?: BulkDocsOptions): async.PouchPromise<BulkDocsResponse[]>;
                 }
             }
 
@@ -683,7 +692,7 @@ declare module pouchdb {
                 /** Promise pattern for close() */
                 interface Promise {
                     /** Closes the pouchdb */
-                    close(): GlobalPromise<string>;
+                    close(): async.PouchPromise<string>;
                 }
             }
 
@@ -717,7 +726,7 @@ declare module pouchdb {
                      * Deletes a database
                      * @param options ajax options
                      */
-                    destroy(options?: options.OptionsWithAjax): GlobalPromise<Info>;
+                    destroy(options?: options.OptionsWithAjax): async.PouchPromise<Info>;
                 }
             }
 
@@ -796,7 +805,7 @@ declare module pouchdb {
                      * @param docId the doc id
                      * @param options
                      */
-                    get<R extends ExistingDoc>(docId: string, options?: Options): GlobalPromise<R>;
+                    get<R extends ExistingDoc>(docId: string, options?: Options): async.PouchPromise<R>;
                 }
             }
 
@@ -810,7 +819,7 @@ declare module pouchdb {
                 /** Promise pattern for `id()` */
                 interface Promise {
                     /** Returns the instance id for the pouchdb */
-                    id(): GlobalPromise<string>;
+                    id(): async.PouchPromise<string>;
                 }
             }
 
@@ -845,7 +854,7 @@ declare module pouchdb {
                 /** Promise pattern for `info()` */
                 interface Promise {
                     /** Returns the instance info for the pouchdb */
-                    info(): GlobalPromise<Response | ResponseDebug>;
+                    info(): async.PouchPromise<Response | ResponseDebug>;
                 }
             }
 
@@ -883,7 +892,7 @@ declare module pouchdb {
                      * @param options ajax options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    post(doc: BaseDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    post(doc: BaseDoc, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                 }
             }
 
@@ -964,14 +973,14 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: ExistingDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    put(doc: ExistingDoc, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                     /**
                      * Create a new document.
                      * @param doc the doc
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: NewDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    put(doc: NewDoc, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                     /**
                      * Update an existing document.
                      * @param doc the doc
@@ -980,7 +989,7 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: BaseDoc, docId: string, docRev: string, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    put(doc: BaseDoc, docId: string, docRev: string, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                     /**
                      * Create a new document. If the document already exists,
                      * you must use the update overload otherwise a conflict will occur.
@@ -989,7 +998,7 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    put(doc: BaseDoc, docId: string, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    put(doc: BaseDoc, docId: string, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                 }
             }
 
@@ -1063,7 +1072,7 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    remove(docId: string, docRev: string, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    remove(docId: string, docRev: string, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                     /**
                      * Deletes the document.
                      * `doc` is required to be a document with at least an `_id` and a `_rev` property.
@@ -1072,14 +1081,14 @@ declare module pouchdb {
                      * @param options
                      * @todo define options shape - docs don't make it clear what this is
                      */
-                    remove(doc: ExistingDoc, options?: options.EmptyOptions): GlobalPromise<OperationResponse>;
+                    remove(doc: ExistingDoc, options?: options.EmptyOptions): async.PouchPromise<OperationResponse>;
                     /**
                      * Deletes the document.
                      * `doc` is required to be a document with at least an `_id` property, `rev` is specified in the `options`.
                      * @param doc the doc (with only an `id` property)
                      * @param options options that specify
                      */
-                    remove(doc: NewDoc, options: RevOptions): GlobalPromise<OperationResponse>;
+                    remove(doc: NewDoc, options: RevOptions): async.PouchPromise<OperationResponse>;
                 }
             }
         }
@@ -1234,7 +1243,7 @@ declare module pouchdb {
          * Usually only a `pouchdb.promise.PouchDB` reference would be kept, assigned by
          * the `then` of the constructor.
          */
-        interface PouchDB extends promise.PouchDB, GlobalPromise<promise.PouchDB> { }
+        interface PouchDB extends promise.PouchDB, async.PouchPromise<promise.PouchDB> { }
     }
 
     /** Static-side interface for PouchDB */
@@ -1372,14 +1381,4 @@ declare module pouchdb {
          */
         new (options: options.ctor.DbName): thenable.PouchDB;
     }
-}
-
-/** Merges declaration with another supplied interface to represent a promise object with custom error typings */
-interface GlobalPromise<T> extends Promise<T> {
-    /** A Promises/A+ `then` implementation */
-    then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
-    then<R>(onFulfilled?: (value: T) => Promise<R> | R, onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
-    /** `catch` implementation as per the pouchdb example docs */
-    catch<R>(onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
-    catch<R>(onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
 }

--- a/pouchdb.d.ts
+++ b/pouchdb.d.ts
@@ -149,7 +149,7 @@ declare module pouchdb {
             catch<R>(onRejected?: (error: pouchdb.async.Error) => Promise<R> | R): Promise<R>;
             catch<R>(onRejected?: (error: pouchdb.async.Error) => void): Promise<R>;
         }
-        /** Callback alternatives to promised */
+        /** Callback alternatives to promises */
         interface Callback<T> {
             /**
              * @param error the error object
@@ -337,8 +337,8 @@ declare module pouchdb {
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
                     allDocs(options: FilterOptions, callback?: async.Callback<Response>): void;
                 }
-                /** Promise pattern for allDocs() */
-                interface Promise {
+                /** Promisable pattern for allDocs() */
+                interface Promisable {
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
                     allDocs(): async.PouchPromise<Response>;
                     /** Fetch multiple documents, indexed and sorted by the `_id`. */
@@ -474,8 +474,8 @@ declare module pouchdb {
                      */
                     bulkDocs(docs: MixedDoc[], options: BulkDocsOptions, callback?: async.Callback<BulkDocsResponse[]>): void;
                 }
-                /** Promise pattern for bulkDocs() */
-                interface Promise {
+                /** Promisable pattern for bulkDocs() */
+                interface Promisable {
                     /**
                      * Update/Delete each doc in an array of documents.
                      * @param folder the documents storage object
@@ -678,8 +678,8 @@ declare module pouchdb {
                 }
                 /** Callback pattern for changes() */
                 interface Callback { }
-                /** Promise pattern for changes() */
-                interface Promise { }
+                /** Promisable pattern for changes() */
+                interface Promisable { }
             }
 
             /** Contains the method and call/return types for close() */
@@ -689,8 +689,8 @@ declare module pouchdb {
                     /** Closes the pouchdb */
                     close(callback?: async.Callback<string>): void;
                 }
-                /** Promise pattern for close() */
-                interface Promise {
+                /** Promisable pattern for close() */
+                interface Promisable {
                     /** Closes the pouchdb */
                     close(): async.PouchPromise<string>;
                 }
@@ -719,9 +719,9 @@ declare module pouchdb {
                     destroy(callback?: async.Callback<Info>): void;
                 }
                 /**
-                 * Promise pattern for destroy
+                 * Promisable pattern for destroy
                  */
-                interface Promise {
+                interface Promisable {
                     /**
                      * Deletes a database
                      * @param options ajax options
@@ -798,8 +798,8 @@ declare module pouchdb {
                      */
                     get<R extends Response>(docId: string, options: Options, callback?: async.Callback<R>): void;
                 }
-                /** Promise pattern for remove */
-                interface Promise {
+                /** Promisable pattern for remove */
+                interface Promisable {
                     /**
                      * Retrieves a document, specified by `docId`.
                      * @param docId the doc id
@@ -816,8 +816,8 @@ declare module pouchdb {
                     /** Returns the instance id for the pouchdb */
                     id(callback?: async.Callback<string>): void;
                 }
-                /** Promise pattern for `id()` */
-                interface Promise {
+                /** Promisable pattern for `id()` */
+                interface Promisable {
                     /** Returns the instance id for the pouchdb */
                     id(): async.PouchPromise<string>;
                 }
@@ -851,8 +851,8 @@ declare module pouchdb {
                     /** Returns the instance info for the pouchdb */
                     info(callback?: async.Callback<Response | ResponseDebug>): void;
                 }
-                /** Promise pattern for `info()` */
-                interface Promise {
+                /** Promisable pattern for `info()` */
+                interface Promisable {
                     /** Returns the instance info for the pouchdb */
                     info(): async.PouchPromise<Response | ResponseDebug>;
                 }
@@ -883,8 +883,8 @@ declare module pouchdb {
                      */
                     post(doc: BaseDoc, options: options.EmptyOptions, callback?: async.Callback<OperationResponse>): void;
                 }
-                /** Promise pattern for post */
-                interface Promise {
+                /** Promisable pattern for post */
+                interface Promisable {
                     /**
                      * Create a new document and let PouchDB auto-generate an _id for it.
                      * (tip: use `put()` instead for better indexing)
@@ -965,8 +965,8 @@ declare module pouchdb {
                      */
                     put(doc: BaseDoc, docId: string, options: options.EmptyOptions, callback?: async.Callback<OperationResponse>): void;
                 }
-                /** Promise pattern for put */
-                interface Promise {
+                /** Promisable pattern for put */
+                interface Promisable {
                     /**
                      * Update an existing document.
                      * @param doc the doc
@@ -1061,8 +1061,8 @@ declare module pouchdb {
                      */
                     remove(doc: NewDoc, options: RevOptions, callback?: async.Callback<OperationResponse>): void;
                 }
-                /** Promise pattern for remove */
-                interface Promise {
+                /** Promisable pattern for remove */
+                interface Promisable {
                     /**
                      * Deletes the document.
                      * `doc` is required to be a document with at least an `_id` and a `_rev` property.
@@ -1109,19 +1109,19 @@ declare module pouchdb {
                 , methods.put.Callback
                 , methods.remove.Callback { }
             /** pouchDB api: promise based */
-            interface Promise extends
+            interface Promisable extends
                 PouchInstance
-                , methods.allDocs.Promise
-                , methods.bulkDocs.Promise
+                , methods.allDocs.Promisable
+                , methods.bulkDocs.Promisable
                 , methods.changes.Overloads
-                , methods.close.Promise
-                , methods.destroy.Promise
-                , methods.get.Promise
-                , methods.id.Promise
-                , methods.info.Promise
-                , methods.post.Promise
-                , methods.put.Promise
-                , methods.remove.Promise { }
+                , methods.close.Promisable
+                , methods.destroy.Promisable
+                , methods.get.Promisable
+                , methods.id.Promisable
+                , methods.info.Promisable
+                , methods.post.Promisable
+                , methods.put.Promisable
+                , methods.remove.Promisable { }
         }
 
         /** The main pouchDB interface */
@@ -1231,15 +1231,15 @@ declare module pouchdb {
         /** The main pouchDB interface (callback pattern) */
         interface PouchDB extends api.db.Callback { }
     }
-    /** The api module for the pouchdb promise pattern */
+    /** The api module for the pouchdb Promisable pattern */
     module promise {
-        /** The main pouchDB interface (promise pattern) */
-        interface PouchDB extends api.db.Promise { }
+        /** The main pouchDB interface (Promisable pattern) */
+        interface PouchDB extends api.db.Promisable { }
     }
     /** The api module for the pouchdb promise pattern (constructor only) */
     module thenable {
         /**
-         * Special case class returned by the constructors of the promise api pouchDB.
+         * Special case class returned by the constructors of the Promisable api pouchDB.
          * Usually only a `pouchdb.promise.PouchDB` reference would be kept, assigned by
          * the `then` of the constructor.
          */
@@ -1253,7 +1253,7 @@ declare module pouchdb {
     }
     /**
      * The main pouchDB entry point. The constructors here will return either a
-     * Callback or Promise pattern api.
+     * Callback or Promisable pattern api.
      */
     export interface PouchDB {
         //////////////////////////////  local db  /////////////////////////////


### PR DESCRIPTION
- [x] Fixed keys definition (`allDocs({keys: ['a', 'b']})`)
- [x] Made it compatible with typescript 1.6 (1.6.2)
- [x] Made it work with external Promise implementations/definitions
- [x] Prettified the main files as per standard VSCode style
- [x] Fixed some UTF-8 ghosts

This one closes https://github.com/AGBrown/pouchdb.d.ts/issues/18 and https://github.com/AGBrown/pouchdb.d.ts/issues/19

Let me know if you need anything else related to these.
